### PR TITLE
[Fix] 게시글 삭제 오류 수정

### DIFF
--- a/src/main/java/com/sejong/creativesemester/board/entity/Board.java
+++ b/src/main/java/com/sejong/creativesemester/board/entity/Board.java
@@ -35,7 +35,7 @@ public class Board extends BaseTimeEntity {
     private String content;
 
     @Builder.Default
-    @OneToMany(mappedBy = "board",cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "board",orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
     //학과 아이디 추가
@@ -44,11 +44,11 @@ public class Board extends BaseTimeEntity {
     private Major major;
 
     //댓글을 적은 사용자 아이디
-    @OneToMany(mappedBy = "board")
+    @OneToMany(mappedBy = "board",orphanRemoval = true)
     private List<Comment> comment;
 
     @JoinColumn(name = "voteId")
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY,orphanRemoval = true)
     private Vote vote;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/sejong/creativesemester/board/service/BoardService.java
+++ b/src/main/java/com/sejong/creativesemester/board/service/BoardService.java
@@ -11,6 +11,7 @@ import com.sejong.creativesemester.common.format.exception.param.NullDeadlineFor
 import com.sejong.creativesemester.common.format.exception.user.NotFoundUserException;
 import com.sejong.creativesemester.image.entity.Image;
 import com.sejong.creativesemester.image.repository.ImageRepository;
+import com.sejong.creativesemester.image.service.ImageService;
 import com.sejong.creativesemester.image.service.dto.res.ImageInfoResponseDto;
 import com.sejong.creativesemester.user.entity.User;
 import com.sejong.creativesemester.board.repository.BoardRepository;
@@ -39,6 +40,7 @@ public class BoardService {
     private final ImageRepository imageRepository;
     private final VoteRepository voteRepository;
     private final BoardRepositoryCustom boardRepositoryCustom;
+    private final ImageService imageService;
 
     // 게시글 추가
     public void createBoard(String studentNum, BoardCreateRequestDto dto, BoardType boardType, boolean isVote) throws Exception {
@@ -163,6 +165,9 @@ public class BoardService {
         if (!isMyBoard(studentNum, board)) {
             throw new NotMatchBoardAndUserException();
         }
+        // 이미지s3에서 삭제하도록 로직 추가하기
+        board.getImages().stream()
+                .parallel().forEach(image -> imageService.deleteImageToS3(image.getImageName()));
         boardRepository.delete(board);
     }
 }


### PR DESCRIPTION
- 게시글과 연관관계 맺어진 다른 엔티티들을 확인하여 게시글 삭제시 모두 삭제해도 되어 orphanRemoval = true 옵션 설정함
- 게시글 삭제시 s3의 이미지도 삭제하도록 수정