### PR TITLE
refactory: 사무내역 조회시 저장시간 응답추가

### DIFF
--- a/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
+++ b/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
@@ -49,9 +49,6 @@ public class AffairController {
     public SuccessResponse<String> removeAffair(@PathVariable Long affairId,
                                                 @RequestBody RemoveAffairRequest removeAffairRequest,
                                                 @ApiIgnore Authentication authentication) {
-        if (!(authentication.getAuthorities().contains("ROLE_COUNCIL") && authentication.getAuthorities().contains("ROLE_ADMIN"))) {
-            throw new NotHaveRoleException();
-        }
         affairService.removeAffair(authentication, affairId, removeAffairRequest);
         return SuccessResponse.ok("사무게시글이 삭제되었습니다.");
     }

--- a/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
+++ b/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
@@ -2,6 +2,7 @@ package com.sejong.creativesemester.affair.controller;
 
 import com.sejong.creativesemester.affair.service.AffairFileInfoResponse;
 import com.sejong.creativesemester.affair.service.AffairService;
+import com.sejong.creativesemester.common.format.exception.user.NotHaveRoleException;
 import com.sejong.creativesemester.common.format.success.SuccessResponse;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,9 @@ import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.List;
+
+import static com.sejong.creativesemester.user.entity.Role.ROLE_ADMIN;
+import static com.sejong.creativesemester.user.entity.Role.ROLE_COUNCIL;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,6 +25,11 @@ public class AffairController {
             notes = "학생회의 사무부서를 맡고 있는 부장이 사무내역을 작성합니다.")
     @PostMapping("/council")
     public SuccessResponse<String> saveAffair(@ApiIgnore Authentication authentication, @RequestBody SaveAffairRequest saveAffairRequest) {
+        if (authentication.getAuthorities().stream().noneMatch(a -> a.getAuthority().equals("ROLE_ADMIN") || a.getAuthority().equals("ROLE_COUNCIL"))) {
+            throw new NotHaveRoleException();
+        }
+
+
         affairService.saveAffair(authentication, saveAffairRequest);
         return SuccessResponse.ok("사무내역이 저장되엇습니다.");
     }
@@ -45,6 +54,9 @@ public class AffairController {
     public SuccessResponse<String> removeAffair(@PathVariable Long affairId,
                                                 @RequestBody RemoveAffairRequest removeAffairRequest,
                                                 @ApiIgnore Authentication authentication) {
+        if (!(authentication.getAuthorities().contains("ROLE_COUNCIL") && authentication.getAuthorities().contains("ROLE_ADMIN"))) {
+            throw new NotHaveRoleException();
+        }
         affairService.removeAffair(authentication, affairId, removeAffairRequest);
         return SuccessResponse.ok("사무게시글이 삭제되었습니다.");
     }

--- a/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
+++ b/src/main/java/com/sejong/creativesemester/affair/controller/AffairController.java
@@ -25,11 +25,6 @@ public class AffairController {
             notes = "학생회의 사무부서를 맡고 있는 부장이 사무내역을 작성합니다.")
     @PostMapping("/council")
     public SuccessResponse<String> saveAffair(@ApiIgnore Authentication authentication, @RequestBody SaveAffairRequest saveAffairRequest) {
-        if (authentication.getAuthorities().stream().noneMatch(a -> a.getAuthority().equals("ROLE_ADMIN") || a.getAuthority().equals("ROLE_COUNCIL"))) {
-            throw new NotHaveRoleException();
-        }
-
-
         affairService.saveAffair(authentication, saveAffairRequest);
         return SuccessResponse.ok("사무내역이 저장되엇습니다.");
     }

--- a/src/main/java/com/sejong/creativesemester/affair/entity/Affair.java
+++ b/src/main/java/com/sejong/creativesemester/affair/entity/Affair.java
@@ -1,5 +1,6 @@
 package com.sejong.creativesemester.affair.entity;
 
+import com.sejong.creativesemester.common.domain.BaseTimeEntity;
 import com.sejong.creativesemester.file.entity.File;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Getter
 @Entity
-public class Affair {
+public class Affair extends BaseTimeEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/com/sejong/creativesemester/affair/service/AffairFileInfoResponse.java
+++ b/src/main/java/com/sejong/creativesemester/affair/service/AffairFileInfoResponse.java
@@ -1,8 +1,11 @@
 package com.sejong.creativesemester.affair.service;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -12,4 +15,7 @@ public class AffairFileInfoResponse {
     private String usedMoney;
     private FileInfo fileInfo;
     private String title;
+
+    @JsonFormat(pattern = "YYYY-MM-dd hh:mm:ss")
+    private LocalDateTime createdTime;
 }

--- a/src/main/java/com/sejong/creativesemester/affair/service/AffairService.java
+++ b/src/main/java/com/sejong/creativesemester/affair/service/AffairService.java
@@ -65,6 +65,7 @@ public class AffairService {
                         .fileName(affair.getFile().getFileName())
                         .fileUrl(affair.getFile().getFileUrl())
                         .build())
+                .createdTime(affair.getCreatedTime())
                 .build();
     }
 

--- a/src/main/java/com/sejong/creativesemester/common/config/SecurityConfig.java
+++ b/src/main/java/com/sejong/creativesemester/common/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig{
         http
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
-                .antMatchers("/api/v1/promise/**").hasRole("COUNCIL")
+                .antMatchers("/api/v1/affair/council/**", "/api/v1/promise/**").hasAnyRole("COUNCIL","ADMIN")
                 .antMatchers("/wss/**","/ws/**","/pub/**","/sub/**","/chat/**","/ws/chat/**","/swagger-ui/**", "/api/v1/auth/**","/h2-console/**", "/health-check").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/sejong/creativesemester/common/config/SecurityConfig.java
+++ b/src/main/java/com/sejong/creativesemester/common/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig{
         http
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
-                .antMatchers("/api/v1/affair/council", "/api/v1/promise/**").hasRole("COUNCIL")
+                .antMatchers("/api/v1/promise/**").hasRole("COUNCIL")
                 .antMatchers("/wss/**","/ws/**","/pub/**","/sub/**","/chat/**","/ws/chat/**","/swagger-ui/**", "/api/v1/auth/**","/h2-console/**", "/health-check").permitAll()
                 .anyRequest().authenticated()
                 .and()


### PR DESCRIPTION
- 사무내역은 일반학우도 접근해야하므로 시큐리티 변경하고, 컨트롤러에서 에러 반환